### PR TITLE
Fix bug and add tests for missing clade bug

### DIFF
--- a/src/Bio/Phylogeny/Internal/PhyloXml.purs
+++ b/src/Bio/Phylogeny/Internal/PhyloXml.purs
@@ -391,7 +391,7 @@ toStructuralTree (Internal p@(XmlNode node) children) =
   -- Structural elements form the phylogeny,
   -- all other elements are attributes.
   isStructuralElement :: Tree XmlNode -> Boolean
-  isStructuralElement (Leaf _) = false
+  isStructuralElement (Leaf (XmlNode { name })) = name == "clade"
   isStructuralElement (Internal (XmlNode { name }) _) =
     A.elem name [ "phyloxml", "phylogeny", "clade" ]
 

--- a/test/js/parsing.ts
+++ b/test/js/parsing.ts
@@ -70,3 +70,39 @@ test("Throws when missing opening paren", (t) => {
 test("Throws when missing closing semicolon", (t) => {
   t.throws(() => parse("()"), { instanceOf: Error });
 });
+
+test("Can parse phyloxml", (t) => {
+  const text =
+    '<phyloxml><phylogeny rooted=\'true\'><clade name="A"><clade><name>B</name><clade name="C" /><clade name="D" /></clade></clade></phylogeny></phyloxml>';
+  const phy = parse(text);
+  t.deepEqual(vertices(phy), [
+    {
+      name: "A",
+      event: "Clade",
+      branchLength: 0,
+      ref: 1,
+      attributes: new Map(),
+    },
+    {
+      name: "B",
+      event: "Clade",
+      branchLength: 0,
+      ref: 2,
+      attributes: new Map(),
+    },
+    {
+      name: "C",
+      event: "Taxa",
+      branchLength: 0,
+      ref: 3,
+      attributes: new Map(),
+    },
+    {
+      name: "D",
+      event: "Taxa",
+      branchLength: 0,
+      ref: 4,
+      attributes: new Map(),
+    },
+  ]);
+});


### PR DESCRIPTION
This bug is triggered by defining a clade in a self closing "leaf" tag. The fix is to avoid universally trating leaves an non-structural but check if a leaf tag is a clade.